### PR TITLE
snapshot of tuf integration branch (not a real PR)

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -15,9 +15,11 @@ from pip._internal.cli.command_context import CommandContextMixIn
 from pip._internal.exceptions import CommandError, PreviousBuildDirError
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.locations import USER_DATA_DIR
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
+from pip._internal.network.tuf import initialize_updaters
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req.constructors import (
     install_req_from_editable,
@@ -57,6 +59,7 @@ class SessionCommandMixin(CommandContextMixIn):
         # type: () -> None
         super(SessionCommandMixin, self).__init__()
         self._session = None  # Optional[PipSession]
+        self._updaters = None
 
     @classmethod
     def _get_index_urls(cls, options):
@@ -122,6 +125,23 @@ class SessionCommandMixin(CommandContextMixIn):
         session.auth.prompting = not options.no_input
 
         return session
+
+    def get_tuf_updaters(self, options):
+        if self._updaters == None:
+            self._updaters = self._initialize_tuf_updaters(options)
+        return self._updaters
+
+    def _initialize_tuf_updaters(self, options):
+        index_urls = self._get_index_urls(options)
+        # TODO does user_data_dir need to be a config option as well?
+        metadata_dir = os.path.join(USER_DATA_DIR, 'tuf')
+        if options.cache_dir:
+            cache_dir = os.path.join(options.cache_dir, "tuf")
+        else:
+            cache_dir = None
+        return initialize_updaters(index_urls, metadata_dir, cache_dir)
+
+
 
 
 class IndexGroupCommand(Command, SessionCommandMixin):

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -416,6 +416,7 @@ class RequirementCommand(IndexGroupCommand):
         self,
         options,               # type: Values
         session,               # type: PipSession
+        updaters,
         target_python=None,    # type: Optional[TargetPython]
         ignore_requires_python=None,  # type: Optional[bool]
     ):
@@ -426,7 +427,7 @@ class RequirementCommand(IndexGroupCommand):
         :param ignore_requires_python: Whether to ignore incompatible
             "Requires-Python" values in links. Defaults to False.
         """
-        link_collector = LinkCollector.create(session, options=options)
+        link_collector = LinkCollector.create(session, updaters, options=options)
         selection_prefs = SelectionPreferences(
             allow_yanked=True,
             format_control=options.format_control,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -126,9 +126,11 @@ class SessionCommandMixin(CommandContextMixIn):
 
         return session
 
+    #TODO SessionCommandMixin is not a great place: research needed
     def get_tuf_updaters(self, options):
         if self._updaters == None:
             self._updaters = self._initialize_tuf_updaters(options)
+        logger.debug("TUF Updaters" + str(self._updaters))
         return self._updaters
 
     def _initialize_tuf_updaters(self, options):
@@ -138,6 +140,7 @@ class SessionCommandMixin(CommandContextMixIn):
         if options.cache_dir:
             cache_dir = os.path.join(options.cache_dir, "tuf")
         else:
+            # TODO: this breaks everything currently: not sure what to do without cache -- use a temp dir?
             cache_dir = None
         return initialize_updaters(index_urls, metadata_dir, cache_dir)
 
@@ -224,6 +227,7 @@ class RequirementCommand(IndexGroupCommand):
         options,                  # type: Values
         req_tracker,              # type: RequirementTracker
         session,                  # type: PipSession
+        updaters,
         finder,                   # type: PackageFinder
         use_user_site,            # type: bool
         download_dir=None,        # type: str
@@ -260,6 +264,7 @@ class RequirementCommand(IndexGroupCommand):
             req_tracker=req_tracker,
             session=session,
             downloader=downloader,
+            updaters=updaters,
             finder=finder,
             require_hashes=options.require_hashes,
             use_user_site=use_user_site,

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -91,11 +91,13 @@ class DownloadCommand(RequirementCommand):
         ensure_dir(options.download_dir)
 
         session = self.get_default_session(options)
+        updaters = self.get_tuf_updaters(options)
 
         target_python = make_target_python(options)
         finder = self._build_package_finder(
             options=options,
             session=session,
+            updaters=updaters,
             target_python=target_python,
         )
         build_delete = (not (options.no_clean or options.build_dir))
@@ -116,6 +118,7 @@ class DownloadCommand(RequirementCommand):
             options=options,
             req_tracker=req_tracker,
             session=session,
+            updaters=updaters,
             finder=finder,
             download_dir=options.download_dir,
             use_user_site=False,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -302,6 +302,7 @@ class InstallCommand(RequirementCommand):
                 options=options,
                 req_tracker=req_tracker,
                 session=session,
+                updaters=self.get_tuf_updaters(options),
                 finder=finder,
                 use_user_site=options.use_user_site,
             )

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -270,11 +270,13 @@ class InstallCommand(RequirementCommand):
         global_options = options.global_options or []
 
         session = self.get_default_session(options)
+        updaters = self.get_tuf_updaters(options)
 
         target_python = make_target_python(options)
         finder = self._build_package_finder(
             options=options,
             session=session,
+            updaters=updaters,
             target_python=target_python,
             ignore_requires_python=options.ignore_requires_python,
         )
@@ -302,7 +304,7 @@ class InstallCommand(RequirementCommand):
                 options=options,
                 req_tracker=req_tracker,
                 session=session,
-                updaters=self.get_tuf_updaters(options),
+                updaters=updaters,
                 finder=finder,
                 use_user_site=options.use_user_site,
             )

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -112,8 +112,9 @@ class WheelCommand(RequirementCommand):
         cmdoptions.check_install_build_global(options)
 
         session = self.get_default_session(options)
+        updaters = self.get_tuf_updaters(options)
 
-        finder = self._build_package_finder(options, session)
+        finder = self._build_package_finder(options, session, updaters)
         build_delete = (not (options.no_clean or options.build_dir))
         wheel_cache = WheelCache(options.cache_dir, options.format_control)
 
@@ -136,6 +137,7 @@ class WheelCommand(RequirementCommand):
             options=options,
             req_tracker=req_tracker,
             session=session,
+            updaters=updaters,
             finder=finder,
             wheel_download_dir=options.wheel_dir,
             use_user_site=False,

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -649,12 +649,15 @@ class LinkCollector(object):
             updater = self.updaters[index_url + '/']
             logger.debug('TUF Updater found: ' + str(updater))
             index_file = updater.download_index(project)
-            with open(index_file, "rb") as f:
-                return HTMLPage(
-                    content=f.read(),
-                    encoding=None,
-                    url=location.url, #TODO should this be the real hashed url?
-                    cache_link_parsing=False)
+            if index_file is None:
+                return None
+            else:
+                with open(index_file, "rb") as f:
+                    return HTMLPage(
+                        content=f.read(),
+                        encoding=None,
+                        url=location.url, #TODO should this be the real hashed url?
+                        cache_link_parsing=False)
         except KeyError:
             logger.debug('TUF Updater not found for index_url ' + index_url)
             return _get_html_page(location, session=self.session)

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -597,14 +597,16 @@ class LinkCollector(object):
     def __init__(
         self,
         session,       # type: PipSession
+        updaters,
         search_scope,  # type: SearchScope
     ):
         # type: (...) -> None
         self.search_scope = search_scope
         self.session = session
+        self.updaters = updaters
 
     @classmethod
-    def create(cls, session, options, suppress_no_index=False):
+    def create(cls, session, updaters, options, suppress_no_index=False):
         # type: (PipSession, Values, bool) -> LinkCollector
         """
         :param session: The Session to use to make requests.
@@ -626,7 +628,7 @@ class LinkCollector(object):
             find_links=find_links, index_urls=index_urls,
         )
         link_collector = LinkCollector(
-            session=session, search_scope=search_scope,
+            session=session, updaters=updaters, search_scope=search_scope,
         )
         return link_collector
 
@@ -640,7 +642,22 @@ class LinkCollector(object):
         """
         Fetch an HTML page containing package links.
         """
-        return _get_html_page(location, session=self.session)
+        # TODO: TUF should only be used for project index files -- is this used for other things?
+        try:
+            index_url, _, project = location.url.rstrip('/').rpartition('/')
+            assert(len(project) > 0)
+            updater = self.updaters[index_url + '/']
+            logger.debug('TUF Updater found: ' + str(updater))
+            index_file = updater.download_index(project)
+            with open(index_file, "rb") as f:
+                return HTMLPage(
+                    content=f.read(),
+                    encoding=None,
+                    url=location.url, #TODO should this be the real hashed url?
+                    cache_link_parsing=False)
+        except KeyError:
+            logger.debug('TUF Updater not found for index_url ' + index_url)
+            return _get_html_page(location, session=self.session)
 
     def collect_links(self, project_name):
         # type: (str) -> CollectedLinks

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -29,6 +29,7 @@ if MYPY_CHECK_RUNNING:
 
 # Application Directories
 USER_CACHE_DIR = appdirs.user_cache_dir("pip")
+USER_DATA_DIR = appdirs.user_data_dir("pip")
 
 
 def get_major_minor_version():

--- a/src/pip/_internal/network/tuf.py
+++ b/src/pip/_internal/network/tuf.py
@@ -37,7 +37,7 @@ class Updater:
                 'url_prefix': base_url,
                 'metadata_path': 'tuf/',
                 'targets_path': targets_path,
-                'confined_target_dirs': ['']
+                'confined_target_dirs': [targets_path]
             }
         }
         self._updater = tuf.client.updater.Updater(dir_name, mirrors)
@@ -60,6 +60,9 @@ class Updater:
         # the distribution mirror is only known after the index
         # files are read: make sure it's configured
 
+        # TODO: split mirror_url into prefix and targets_path ?
+        # This would allow using confined_target_dirs to prevent
+        # index file requests being made to this mirror
         if mirror_url not in self._updater.mirrors:
             self._updater.mirrors[mirror_url] = {
                 'url_prefix': mirror_url,

--- a/src/pip/_internal/network/tuf.py
+++ b/src/pip/_internal/network/tuf.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import os.path
 
+from pip._internal.exceptions import NetworkConnectionError
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
 # TODO vendor tuf
@@ -130,25 +131,28 @@ class Updater:
     # Requires a link with url and comes_from
     #   url is e.g. https://files.pythonhosted.org/packages/8f/1f/74aa91b56dea5847b62e11ce6737db82c6446561bddc20ca80fa5df025cc/Django-1.1.3.tar.gz#sha256=0e5034cf8046ba77c62e95a45d776d2c59998b26f181ceaf5cec516115e3f85a
     #   comes_from is e.g. "https://pypi.org/simple/django"
-    # Raises NoWorkingMirrorError, ?
+    # Raises NetworkConnectionError, ?
     def download_distribution(self, link):
         # TODO double check that comes_from matches our index_url
+        try:
+            self._ensure_fresh_metadata()
 
-        self._ensure_fresh_metadata()
+            base_url, target_name = self._split_distribution_url(link)
+            self._ensure_distribution_mirror_config(base_url)
+            self._updater.mirrors = self._distribution_mirrors
 
-        base_url, target_name = self._split_distribution_url(link)
-        self._ensure_distribution_mirror_config(base_url)
-        self._updater.mirrors = self._distribution_mirrors
+            logger.debug("Getting TUF target_info for " + target_name)
+            target = self._updater.get_one_valid_targetinfo(target_name)
 
-        logger.debug("Getting TUF target_info for " + target_name)
-        target = self._updater.get_one_valid_targetinfo(target_name)
-        
-        # TODO decide cache dir strategy. Currently the whole
-        # directory structure is created in _cache_dir. Also 'None' cache dir breaks everything
-        if self._updater.updated_targets([target], self._cache_dir):
-            self._updater.download_target(target, self._cache_dir, prefix_filename_with_hash=False)
-        return os.path.join(self._cache_dir, target_name)
-
+            # TODO decide cache dir strategy. Currently the whole
+            # directory structure is created in _cache_dir. Also 'None' cache dir breaks everything
+            if self._updater.updated_targets([target], self._cache_dir):
+                self._updater.download_target(target, self._cache_dir, prefix_filename_with_hash=False)
+            return os.path.join(self._cache_dir, target_name)
+        except NoWorkingMirrorError as e:
+            # This is close but not strictly speaking always true: there might
+            # be other reasons for NoWorkingMirror than Network issues
+            raise NetworkConnectionError(e)
 
 
 # Return a dictionary of index_url:Updater

--- a/src/pip/_internal/network/tuf.py
+++ b/src/pip/_internal/network/tuf.py
@@ -48,6 +48,10 @@ class Updater:
         self._cache_dir = cache_dir
 
 
+    def __str__(self):
+        return str(self._updater)
+
+
     # Make sure we have refreshed metadata exactly once (we
     # want all downloads to be done from a consistent repository)
     # Raises NoWorkingMirrorError, ?

--- a/src/pip/_internal/network/tuf.py
+++ b/src/pip/_internal/network/tuf.py
@@ -116,13 +116,11 @@ class Updater:
 
         base_url, target_name = self._split_distribution_url(link)
         self._ensure_mirror_config(base_url)
-
+        logger.debug("Getting TUF target_info for " + target_name)
         target = self._updater.get_one_valid_targetinfo(target_name)
         
         # TODO decide cache dir strategy. Currently the whole
-        # directory structure is created in dl_dir: that is super wrong.
-        # on the other hand e.g. 'pip download' expects us to not download
-        # things if dl_dir already contains the file...
+        # directory structure is created in _cache_dir. Also 'None' cache dir breaks everything
         if self._updater.updated_targets([target], self._cache_dir):
             self._updater.download_target(target, self._cache_dir, prefix_filename_with_hash=False)
         return os.path.join(self._cache_dir, target_name)
@@ -130,13 +128,14 @@ class Updater:
 
 
 # Return a dictionary of index_url:Updater
-# The dict will contain updaters for every index_url
-# that we have local metadata for
-# TODO This should maybe be a TUFSession object?
+# The dict will contain updaters for every index_url that we have local metadata for
+# TODO return value should maybe be a "TUFSession" object -- it could provide some extra
+# functionality like updater lookup based on distribution download Link (currently
+# implemented in prepare.py:get_http_url() )
 def initialize_updaters(index_urls, metadata_dir, cache_dir):
     if not os.path.isdir(metadata_dir):
         # TODO should create this path or no?
-        raise NotADirectoryError # TODO not in py2
+        raise NotADirectoryError(metadata_dir) # TODO not in py2
 
     # global TUF settings
     tuf.settings.repositories_directory = metadata_dir

--- a/src/pip/_internal/network/tuf.py
+++ b/src/pip/_internal/network/tuf.py
@@ -36,7 +36,7 @@ class Updater:
                 'url_prefix': base_url,
                 'metadata_path': 'tuf/',
                 'targets_path': targets_path,
-                'confined_target_dirs': [targets_path]
+                'confined_target_dirs': ['']
             }
         }
         self._updater = tuf.client.updater.Updater(dir_name, mirrors)
@@ -92,16 +92,16 @@ class Updater:
     # "https://pypi.org/simple/django"
     # Raises NoWorkingMirrorError, ?
     def download_index(self, project_name):
-        # TODO double check that this seems like an index file URL? e.g. make sure it starts with index_url
-
         self._ensure_fresh_metadata()
 
-        target = self._updater.get_one_valid_targetinfo(project_name)
+        # TODO warehouse setup for hashed index files is still undecided: this assumes /simple/{PROJECT}/{HASH}.index.html
+        target_name = project_name + "/index.html"
+        target = self._updater.get_one_valid_targetinfo(target_name)
         if self._updater.updated_targets([target], self._cache_dir):
             self._updater.download_target(target, self._cache_dir)
 
         # TODO possibly we want to return contents of the file instead?
-        return os.path.join(self._cache_dir, project_name)
+        return os.path.join(self._cache_dir, target_name)
 
 
     # Download a distribution file
@@ -131,7 +131,7 @@ class Updater:
 # The dict will contain updaters for every index_url that we have local metadata for
 # TODO return value should maybe be a "TUFSession" object -- it could provide some extra
 # functionality like updater lookup based on distribution download Link (currently
-# implemented in prepare.py:get_http_url() )
+# implemented in prepare.py:get_http_url()) or lookup that at least canonicalizes the URL
 def initialize_updaters(index_urls, metadata_dir, cache_dir):
     if not os.path.isdir(metadata_dir):
         # TODO should create this path or no?

--- a/src/pip/_internal/network/tuf.py
+++ b/src/pip/_internal/network/tuf.py
@@ -1,0 +1,149 @@
+""" TUF (TheUpdateFramework) integration
+"""
+
+from collections import namedtuple
+import hashlib
+import logging
+import os.path
+
+from pip._vendor.six.moves.urllib import parse as urllib_parse
+
+# TODO vendor tuf
+import tuf.client.updater
+from tuf.exceptions import (
+    RepositoryError,
+)
+import tuf.settings
+
+
+logger = logging.getLogger(__name__)
+
+
+# TUF Updater abstraction for a specific Warehouse instance (index URL)
+class Updater:
+    # throws RepositoryError, ?
+    def __init__(self, index_url, metadata_dir, cache_dir):
+        # Construct unique directory name based on the url
+        # TODO make sure this is robust
+        dir_name = hashlib.sha224(index_url.encode('utf-8')).hexdigest()
+        
+        # we expect metadata and index files to be hosted on same netloc
+        split_url = urllib_parse.urlsplit(index_url)
+        base_url = urllib_parse.urlunsplit([split_url.scheme, split_url.netloc, '', '', ''])
+        targets_path = split_url.path.lstrip('/')
+        # TODO: metadata_path should not be hard coded but solution is not decided yet
+        mirrors = {
+            base_url: {
+                'url_prefix': base_url,
+                'metadata_path': 'tuf/',
+                'targets_path': targets_path,
+                'confined_target_dirs': ['']
+            }
+        }
+        self._updater = tuf.client.updater.Updater(dir_name, mirrors)
+        self._refreshed = False
+        self.index_cache_dir = os.path.join(cache_dir, 'tuf','index')
+
+
+    # Make sure we have refreshed metadata exactly once (we
+    # want all downloads to be done from a consistent repository)
+    # Raises NoWorkingMirrorError, ?
+    def _ensure_fresh_metadata(self):
+        if not self._refreshed:
+            self._updater.refresh()
+            self._refreshed = True
+
+
+    # Ensure give mirror is in updater mirror config
+    def _ensure_mirror_config(self, mirror_url):
+        # metadata/index mirror config is known from the start, but 
+        # the distribution mirror is only known after the index
+        # files are read: make sure it's configured
+
+        if mirror_url not in self._updater.mirrors:
+            self._updater.mirrors[mirror_url] = {
+                'url_prefix': mirror_url,
+                'metadata_path': 'None', # TODO: Actual None does not work with current tuf 
+                'targets_path': '',
+                'confined_target_dirs': ['']
+            }
+
+
+    # split a distribution url into base path and target name:
+    # "https://files.pythonhosted.org/packages/8f/1f/74aa91b56dea5847b62e11ce6737db82c6446561bddc20ca80fa5df025cc/Django-1.1.3.tar.gz#sha256=0e5034cf8046ba77c62e95a45d776d2c59998b26f181ceaf5cec516115e3f85a"
+    #    ->
+    # ("https://files.pythonhosted.org/packages/", "8f/1f/74aa91b56dea5847b62e11ce6737db82c6446561bddc20ca80fa5df025cc/Django-1.1.3.tar.gz")
+    def _split_distribution_url(self, link):
+        # TODO replace the hack with a proper split based on
+        # knowledge of the hash
+        base_url = urllib_parse.urlunsplit([link.scheme, link.netloc, "/packages/", "", ""])
+        target = link.path[len("/packages/"):]
+        return base_url, target
+
+
+    # Download project index file, return file name
+    # project name is e.g. 'django'. From pypi this will download
+    # "https://pypi.org/simple/django"
+    # Raises NoWorkingMirrorError, ?
+    def download_index(self, project_name):
+        # TODO double check that this seems like an index file URL? e.g. make sure it starts with index_url
+
+        self._ensure_fresh_metadata()
+
+        target = self._updater.get_one_valid_targetinfo(project_name)
+        if self._updater.updated_targets([target], self.index_cache_dir):
+            self._updater.download_target(target, self.index_cache_dir)
+
+        # TODO possibly we want to return contents of the file instead?
+        return os.path.join(self.index_cache_dir, project_name)
+
+
+    # Download a distribution file
+    # Requires a link with url and comes_from
+    #   url is e.g. https://files.pythonhosted.org/packages/8f/1f/74aa91b56dea5847b62e11ce6737db82c6446561bddc20ca80fa5df025cc/Django-1.1.3.tar.gz#sha256=0e5034cf8046ba77c62e95a45d776d2c59998b26f181ceaf5cec516115e3f85a
+    #   comes_from is e.g. "https://pypi.org/simple/django"
+    # Raises NoWorkingMirrorError, ?
+    def download_distribution(self, link, dl_dir):
+        # TODO double check that comes_from matches our index_url
+
+        self._ensure_fresh_metadata()
+
+        base_url, target_name = self._split_distribution_url(link)
+        self._ensure_mirror_config(base_url)
+
+        target = self._updater.get_one_valid_targetinfo(target_name)
+        
+        # TODO decide cache dir strategy. Currently the whole
+        # directory structure is created in dl_dir: that is wrong.
+        if self._updater.updated_targets([target], dl_dir):
+            # TODO: should use prefix_filename_with_hash=False once TUF issue #1080 is fixed
+            self._updater.download_target(target, dl_dir, prefix_filename_with_hash=False)
+
+
+
+# Return a dictionary of index_url:Updater
+# The dict will contain updaters for every index_url
+# that we have local metadata for
+def initialize_updaters(index_urls, metadata_dir, cache_dir):
+    if not os.path.isdir(metadata_dir):
+        # TODO should create this path or no?
+        raise NotADirectoryError # TODO not in py2
+
+    # global TUF settings
+    tuf.settings.repositories_directory = metadata_dir
+    tuf.log.set_log_level(logging.INFO)
+
+    # Initialize updaters for index_urls with local metadata
+    updaters = {}
+    for index_url in index_urls:
+        # TODO: should canonicalize index_url: at least the last slash
+        try:
+            updaters[index_url] = Updater(index_url, metadata_dir, cache_dir)
+        except RepositoryError as e:
+            # No TUF Metadata was found for this index_url
+            # TODO: must check for actual metadata file existence
+            # otherwise RepositoryError means "no local metadata"
+            # and "something is wrong"
+            logger.info("Failed to find TUF repo for '%s': %s", index_url, e)
+    
+    return updaters

--- a/src/pip/_internal/network/tuf.py
+++ b/src/pip/_internal/network/tuf.py
@@ -158,7 +158,7 @@ def initialize_updaters(index_urls, metadata_dir, cache_dir):
 
     # global TUF settings
     tuf.settings.repositories_directory = metadata_dir
-    tuf.log.set_log_level(logging.INFO)
+    tuf.log.set_log_level(logging.ERROR)
 
     # Initialize updaters for index_urls with local metadata
     updaters = {}

--- a/src/pip/_internal/utils/appdirs.py
+++ b/src/pip/_internal/utils/appdirs.py
@@ -33,6 +33,11 @@ def user_config_dir(appname, roaming=True):
     return path
 
 
+def user_data_dir(appname):
+    # type: (str) -> str
+    return _appdirs.user_data_dir(appname)
+
+
 # for the discussion regarding site_config_dir locations
 # see <https://github.com/pypa/pip/issues/1733>
 def site_config_dirs(appname):


### PR DESCRIPTION

**Foreword**

This branch is very much a work in progress (full 10% of the lines are "TODO"): please don't review details, I'm just hoping to validate (or even just communicate) the high level ideas and maybe get some new insights at that level. 

My current work is a little ahead of this branch but I think this is more useful for the purposes of discussion and this branch actually works (for pip install at least)...

I don't expect you to do this but if you do want to test:
* get mock warehouse from git@gist.github.com:2cd1077aab8235a3a497c233090ea7e4.git
* setup as described in mock warehouse README, start the server
* run pip from source https://pip.pypa.io/en/stable/development/getting-started/#running-pip-from-source-tree
* pip install --index-url http://localhost:8000/simple/ sampleproject


**Normal flow of the tuf-related code in "pip install sampleproject"**

1. A dictionary of updater objects is built during initialization (currently in `SessionCommandMixin`). 
2. When the dependency calculation needs an index file it ends up in `LinkCollector._get_html_page()`, this looks up an updater object based on the index url (currently quite unsafely), downloads the index file with tuf and returns the contents
3. When distribution needs to be downloaded prepare.py:`get_http_url()` is called. This looks up an updater object based on "comes_from" field (which is the url of the index file this distribution url was found in), and downloads the target this url refers to


Open questions on the flow

* updaters are looked up with index_urls. If one is not found, that means TUF is not used for this download: instead the current download functionality (without TUF) is used. This feels fragile considering I don't have full knowledge of where the index urls come from...  but I don't see other solutions.

* Where to do the initialization is undecided: I think one of the CommandMixins is correct, possibly even a new one

* There are loads of possibilities for when to "intercept" the index and distribution download code: the current places are the easiest but the decision should probably be based on what is least likely to break in future (so TUF support does not get accidentally turned off)

* with the previous point in mind, I'm thinking I'll add a hard-coded warning/error for pypi.org: if we end up downloading things from pypi without TUF, that sounds like an error. I'm not sure same can be done for files.pythonhosted.org


**Data storage**

Cache is in ~/.cache/pip/. It's used as the tuf download location so contains everything ever downloaded with tuf

TUF metadata is in ~/.local/share/pip/. 

Open questions on data storage
* metadata directory name (per repository): currently this is a hash of index url -- could it be human readable? is that even useful?
* is cache cleaning required? No good ideas about this
* what to do when '--no-cache' is used? I think pip has a temp directory that could be used...
* there is no way to check if local metadata is available via TUF api: I'll need to check manually I think
* I think this may lead to unnecessary copying of target files -- but this may also already be the case in pip


**TUF updater abstraction in pip code**

This is code in src/pip/_internal/network/tuf.py. The code _badly_ needs better naming ('Updater' and 'tuf' names are used very confusingly) -- ideas are welcome. 

But the basic design is simple:
* initialize_updaters() forms a dictionary of Updater objects: one object for each metadata dir found for index urls used in current pip configuration.
* Updater object owns the tuf Updater object and the two mirror configurations needed (one for downloading index files, one for distribution files)
* the distribution mirror config gets modified "at runtime" because we don't know what the distribution file server is before we actually get to downloading target files
* Updater object offers download_distribution() and download_index() as high level functionality

So a user will first lookup the correct updater using the index_url of the repository, then call the download functions on that updater.

Open questions:
* Naming!
* initialize_updaters() should probably return an actual object that could offer a better API than just dictionary lookup: The awful index url parsing should be in a single place at least
* _split_distribution_url(): Warehouse devs were fine with my idea of finding the target name from the download url using the knowledge that the hash is X characters long but I'm still thinking if it really is a good idea... 
